### PR TITLE
Add new --quiet flag

### DIFF
--- a/lib/dehinter/__main__.py
+++ b/lib/dehinter/__main__.py
@@ -60,6 +60,7 @@ def run(argv: List[str]) -> None:
     parser.add_argument(
         "--keep-head", help="do not modify head table", action="store_true"
     )
+    parser.add_argument("--quiet", help="silence standard output", action="store_true")
     parser.add_argument("INFILE", help="in file path (hinted font)")
 
     args = parser.parse_args(argv)
@@ -105,6 +106,8 @@ def run(argv: List[str]) -> None:
         )
         sys.exit(1)
 
+    use_verbose_output = not args.quiet
+
     dehint(
         tt,
         keep_cvar=args.keep_cvar,
@@ -119,7 +122,7 @@ def run(argv: List[str]) -> None:
         keep_prep=args.keep_prep,
         keep_ttfa=args.keep_ttfa,
         keep_vdmx=args.keep_vdmx,
-        verbose=True,
+        verbose=use_verbose_output,
     )
 
     # File write
@@ -134,7 +137,8 @@ def run(argv: List[str]) -> None:
 
     try:
         tt.save(outpath)
-        print(f"{os.linesep}[+] Saved dehinted font as '{outpath}'")
+        if use_verbose_output:
+            print(f"{os.linesep}[+] Saved dehinted font as '{outpath}'")
     except Exception as e:  # pragma: no cover
         sys.stderr.write(
             f"[!] Error: Unable to save dehinted font file: {str(e)}{os.linesep}"
@@ -142,10 +146,11 @@ def run(argv: List[str]) -> None:
 
     # File size comparison
     # --------------------
-    infile_size_tuple = get_filesize(args.INFILE)
-    outfile_size_tuple = get_filesize(
-        outpath
-    )  # depends on outpath definition defined during file write
-    print(f"{os.linesep}[*] File sizes:")
-    print(f"    {infile_size_tuple[0]}{infile_size_tuple[1]} (hinted)")
-    print(f"    {outfile_size_tuple[0]}{outfile_size_tuple[1]} (dehinted)")
+    if use_verbose_output:
+        infile_size_tuple = get_filesize(args.INFILE)
+        outfile_size_tuple = get_filesize(
+            outpath
+        )  # depends on outpath definition defined during file write
+        print(f"{os.linesep}[*] File sizes:")
+        print(f"    {infile_size_tuple[0]}{infile_size_tuple[1]} (hinted)")
+        print(f"    {outfile_size_tuple[0]}{outfile_size_tuple[1]} (dehinted)")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,7 +39,7 @@ def font_validator(filepath):
     assert (tt["head"].flags & 1 << 4) == 0
 
 
-def test_default_run_roboto():
+def test_default_run_roboto(capsys):
     test_dir = os.path.join("tests", "test_files", "fonts", "temp")
     notouch_inpath = os.path.join("tests", "test_files", "fonts", "Roboto-Regular.ttf")
     test_inpath = os.path.join(
@@ -58,6 +58,8 @@ def test_default_run_roboto():
 
     # execute
     run(test_args)
+    captured = capsys.readouterr()
+    assert "Saved dehinted font as" in captured.out
 
     # test
     font_validator(test_outpath)
@@ -536,6 +538,35 @@ def test_run_with_outfile_path_noto():
 
     # execute
     run(test_args)
+
+    # test
+    font_validator(test_outpath)
+
+    # tear down
+    shutil.rmtree(test_dir)
+
+
+def test_default_run_roboto_quiet_flag_stdout_test(capsys):
+    test_dir = os.path.join("tests", "test_files", "fonts", "temp")
+    notouch_inpath = os.path.join("tests", "test_files", "fonts", "Roboto-Regular.ttf")
+    test_inpath = os.path.join(
+        "tests", "test_files", "fonts", "temp", "Roboto-Regular.ttf"
+    )
+    test_outpath = os.path.join(
+        "tests", "test_files", "fonts", "temp", "Roboto-Regular-dehinted.ttf"
+    )
+    test_args = ["--quiet", test_inpath]
+
+    # setup
+    if os.path.isdir(test_dir):
+        shutil.rmtree(test_dir)
+    os.mkdir(test_dir)
+    shutil.copyfile(notouch_inpath, test_inpath)
+
+    # execute
+    run(test_args)
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
     # test
     font_validator(test_outpath)


### PR DESCRIPTION
Silences all standard output from the dehinter executable

Based on new lib source verbose feature support from @felipesanches in https://github.com/source-foundry/dehinter/pull/61