### PR TITLE
Remove cPython 3.6 support

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.7"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-coverage.yml
+++ b/.github/workflows/py-coverage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-typecheck.yml
+++ b/.github/workflows/py-typecheck.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ LICENSE = "Apache License v2.0"
 URL = "https://github.com/source-foundry/dehinter"
 EMAIL = "chris@sourcefoundry.org"
 AUTHOR = "Source Foundry Authors and Contributors"
-REQUIRES_PYTHON = ">=3.6.0"
+REQUIRES_PYTHON = ">=3.7.0"
 
 INSTALL_REQUIRES = [
     "fontTools",
@@ -80,9 +80,10 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Text Processing :: Fonts",
         "Topic :: Multimedia :: Graphics",
         "Topic :: Multimedia :: Graphics :: Graphics Conversion",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39
+envlist = py310
 
 [testenv]
 commands =


### PR DESCRIPTION
Py3.6 support was removed in our fontTools dependency.  We will follow suit to support dependency updates